### PR TITLE
Update ChartJs.php

### DIFF
--- a/assets/css/styles.min.css
+++ b/assets/css/styles.min.css
@@ -1,0 +1,1 @@
+.chart-label{padding:5px;margin:5px;color:#FFF;-webkit-border-radius:5px;-khtml-border-radius:5px;-moz-border-radius:5px;border-radius:5px;-webkit-box-shadow:2px 2px 5px #202020;-moz-box-shadow:2px 2px 5px #202020;box-shadow:2px 2px 5px #202020;text-shadow:0 -1px 1px #666,0 1px 1px #FFF}.labels{display:block}

--- a/components/ChartJs.php
+++ b/components/ChartJs.php
@@ -35,7 +35,7 @@ class ChartJs extends CApplicationComponent
             return $this->_assetsUrl;
         else
         {
-            $assetsPath = Yii::getPathOfAlias('chartjs.assets');
+            $assetsPath = dirname(__FILE__) . '/../assets';
             $assetsUrl = Yii::app()->assetManager->publish($assetsPath, false, -1, $this->forceCopyAssets);
             return $this->_assetsUrl = $assetsUrl;
         }


### PR DESCRIPTION
Set the `assetsPath` relative to the file itself. This fixes a bug which caused `chartjs/assets` folders to be added to the `myApp/assets` folder recursively. Also eliminates the need for a `chartjs` alias.
